### PR TITLE
Add skill share command to fork repos and create PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,37 @@ skills-repo/
 | `skill config show` | Show current configuration |
 | `skill config set-repo <url>` | Change configured repository |
 | `skill config verify` | Verify repository access |
+| `skill list` | List available or installed skills |
+| `skill install <name>` | Install a skill to a provider (Claude, Cursor) |
+| `skill share --path <path>` | Share a skill by forking and creating a PR |
 | `skill --help` | Show general help |
 | `skill --version` | Show CLI version |
+
+### Share a skill
+
+```bash
+# Share a skill to the current active repository
+skill share --path ./my-skill
+
+# Share a skill to a specific repository
+skill share --path ./my-skill --repo https://github.com/org/skills-repo.git
+
+# Share a skill with SSH URL
+skill share --path ~/skills/deploy-app --repo git@github.com:org/skills.git
+```
+
+The share command:
+1. Validates the skill structure (requires SKILL.md)
+2. Forks the target repository
+3. Creates a new branch
+4. Copies the skill folder
+5. Commits and pushes changes
+6. Creates a pull request
+7. Returns the PR URL
+
+**Requirements:**
+- `gh` CLI must be installed and authenticated
+- Skill must have a valid structure with SKILL.md file
 
 ### Coming Soon
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -48,6 +48,7 @@ a configured remote repository.
 
   %s                %s
   %s %s
+  %s %s
 
   %s              %s
   %s                     %s
@@ -58,6 +59,7 @@ a configured remote repository.
   %s        %s
 
 %s
+  %s
   %s
   %s
   %s
@@ -84,6 +86,7 @@ a configured remote repository.
 
 		yellow("list [flags]"), dim("List available or installed skills"),
 		yellow("install <skill-name> [flags]"), dim("Install a skill to a provider"),
+		yellow("share --path <path> [flags]"), dim("Share a skill via PR"),
 
 		yellow("help [command]"), dim("Show help for any command"),
 		yellow("version"), dim("Show version information"),
@@ -97,6 +100,7 @@ a configured remote repository.
 		green("skill repository add myrepo https://github.com/org/skills.git"),
 		green("skill list"),
 		green("skill install explain-code --provider claude"),
+		green("skill share --path ./my-skill"),
 		green("skill config show"),
 
 		dim("Use \"skill [command] --help\" for more information about a command."),
@@ -128,6 +132,7 @@ func init() {
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(installCmd)
+	rootCmd.AddCommand(shareCmd)
 }
 
 // initConfig reads the configuration

--- a/internal/cli/share.go
+++ b/internal/cli/share.go
@@ -1,0 +1,476 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/silvinalucero/skill_cli/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var (
+	sharePath string
+	shareRepo string
+)
+
+// getShareHelp returns colored help text for share command
+func getShareHelp() string {
+	cyan := color.New(color.FgCyan, color.Bold).SprintFunc()
+	green := color.New(color.FgGreen).SprintFunc()
+	yellow := color.New(color.FgYellow).SprintFunc()
+	dim := color.New(color.Faint).SprintFunc()
+
+	return fmt.Sprintf(`%s
+
+%s
+  %s            %s
+
+%s
+  %s             %s
+  %s             %s
+
+%s
+  1. Validates the skill structure (must have SKILL.md)
+  2. Forks the target repository using gh CLI
+  3. Creates a new branch
+  4. Copies the skill folder to the forked repository
+  5. Commits and pushes the changes
+  6. Creates a pull request against main branch
+  7. Returns the PR URL
+
+%s
+  my-skill/
+  ├── SKILL.md          # Required: instructions + metadata
+  ├── scripts/          # Optional: executable code
+  ├── references/       # Optional: documentation
+  └── assets/           # Optional: templates, resources
+
+%s
+  - gh CLI must be installed and authenticated
+  - You must have permissions to fork the target repository
+
+%s
+  %s                    %s
+  %s      %s
+  %s`,
+		"Share a skill by forking a repository and creating a PR.",
+
+		cyan("PARAMETERS:"),
+		yellow("<path>"), dim("Path to the skill folder to share (required)"),
+
+		cyan("FLAGS:"),
+		green("--path <path>"), dim("Path to the skill folder (required)"),
+		green("--repo <url>"), dim("Target repository URL (optional, defaults to current)"),
+
+		cyan("WORKFLOW:"),
+
+		cyan("SKILL STRUCTURE:"),
+
+		cyan("REQUIREMENTS:"),
+
+		cyan("EXAMPLES:"),
+		green("skill share --path ./my-skill"), dim("# Share to current repo"),
+		green("skill share --path ./my-skill --repo https://github.com/org/skills"), dim("# Share to specific repo"),
+		green("skill share --path ~/skills/deploy-app --repo git@github.com:org/skills.git"),
+	)
+}
+
+// shareCmd represents the share command
+var shareCmd = &cobra.Command{
+	Use:   "share --path <path> [--repo <url>]",
+	Short: "Share a skill by forking a repo and creating a PR",
+	Long:  getShareHelp(),
+	RunE:  runShare,
+}
+
+func init() {
+	shareCmd.Flags().StringVar(&sharePath, "path", "", "path to the skill folder (required)")
+	shareCmd.Flags().StringVar(&shareRepo, "repo", "", "target repository URL (optional, defaults to current)")
+	shareCmd.MarkFlagRequired("path")
+}
+
+func runShare(cmd *cobra.Command, args []string) error {
+	// Colors for output
+	green := color.New(color.FgGreen).SprintFunc()
+	red := color.New(color.FgRed).SprintFunc()
+	cyan := color.New(color.FgCyan).SprintFunc()
+	yellow := color.New(color.FgYellow).SprintFunc()
+
+	// Convert path to absolute path
+	absPath, err := filepath.Abs(sharePath)
+	if err != nil {
+		fmt.Printf("%s Error resolving path: %v\n", red("✗"), err)
+		return err
+	}
+
+	// Step 1: Validate skill structure
+	fmt.Printf("%s Validating skill structure...\n", cyan("→"))
+	skillName := filepath.Base(absPath)
+
+	valid, warnings, err := validateSkillStructure(absPath)
+	if err != nil {
+		fmt.Printf("%s %v\n", red("✗"), err)
+		return err
+	}
+
+	if !valid {
+		fmt.Printf("%s Skill structure is invalid\n", red("✗"))
+		return fmt.Errorf("invalid skill structure")
+	}
+
+	// Show warnings if any
+	if len(warnings) > 0 {
+		fmt.Printf("%s Warnings:\n", yellow("⚠"))
+		for _, warning := range warnings {
+			fmt.Printf("  - %s\n", warning)
+		}
+		fmt.Println()
+
+		// Ask user if they want to continue
+		fmt.Print("Do you want to continue anyway? (y/N): ")
+		reader := bufio.NewReader(os.Stdin)
+		response, _ := reader.ReadString('\n')
+		response = strings.TrimSpace(strings.ToLower(response))
+
+		if response != "y" && response != "yes" {
+			fmt.Printf("%s Share cancelled by user\n", yellow("⚠"))
+			return nil
+		}
+	}
+
+	fmt.Printf("%s Skill structure validated: %s\n", green("✓"), skillName)
+	fmt.Println()
+
+	// Step 2: Determine target repository
+	var targetRepo string
+	if shareRepo != "" {
+		targetRepo = shareRepo
+	} else {
+		// Use current/active repository
+		if !config.Exists() {
+			fmt.Printf("%s Configuration not found\n", red("✗"))
+			fmt.Println("  Run 'skill repository add <name> <repo-url>' to initialize")
+			return fmt.Errorf("configuration not found")
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			fmt.Printf("%s Error loading configuration: %v\n", red("✗"), err)
+			return err
+		}
+
+		if cfg.ActiveRepo == "" {
+			fmt.Printf("%s No active repository configured\n", red("✗"))
+			return fmt.Errorf("no active repository")
+		}
+
+		repo, err := config.GetRepo(cfg, cfg.ActiveRepo)
+		if err != nil {
+			fmt.Printf("%s Error getting active repository: %v\n", red("✗"), err)
+			return err
+		}
+
+		targetRepo = repo.URL
+	}
+
+	fmt.Printf("%s Target repository: %s\n", cyan("→"), targetRepo)
+	fmt.Println()
+
+	// Step 3: Check gh CLI is installed
+	fmt.Printf("%s Checking gh CLI...\n", cyan("→"))
+	if err := checkGHInstalled(); err != nil {
+		fmt.Printf("%s %v\n", red("✗"), err)
+		fmt.Println("  Install gh CLI: https://cli.github.com/")
+		return err
+	}
+	fmt.Printf("%s gh CLI is available\n", green("✓"))
+	fmt.Println()
+
+	// Step 4: Fork the repository
+	fmt.Printf("%s Forking repository...\n", cyan("→"))
+	forkURL, err := forkRepository(targetRepo)
+	if err != nil {
+		fmt.Printf("%s Error forking repository: %v\n", red("✗"), err)
+		return err
+	}
+	fmt.Printf("%s Repository forked: %s\n", green("✓"), forkURL)
+	fmt.Println()
+
+	// Step 5: Clone the fork to a temporary directory
+	fmt.Printf("%s Cloning fork...\n", cyan("→"))
+	tempDir, err := os.MkdirTemp("", "skill-share-*")
+	if err != nil {
+		fmt.Printf("%s Error creating temporary directory: %v\n", red("✗"), err)
+		return err
+	}
+	defer os.RemoveAll(tempDir)
+
+	if err := cloneRepository(forkURL, tempDir); err != nil {
+		fmt.Printf("%s Error cloning fork: %v\n", red("✗"), err)
+		return err
+	}
+	fmt.Printf("%s Fork cloned to temporary directory\n", green("✓"))
+	fmt.Println()
+
+	// Step 6: Create a new branch
+	branchName := fmt.Sprintf("add-skill-%s", skillName)
+	fmt.Printf("%s Creating branch '%s'...\n", cyan("→"), branchName)
+	if err := createBranch(tempDir, branchName); err != nil {
+		fmt.Printf("%s Error creating branch: %v\n", red("✗"), err)
+		return err
+	}
+	fmt.Printf("%s Branch created\n", green("✓"))
+	fmt.Println()
+
+	// Step 7: Copy skill folder to the repository
+	fmt.Printf("%s Copying skill folder...\n", cyan("→"))
+	destPath := filepath.Join(tempDir, skillName)
+	if err := copyDir(absPath, destPath); err != nil {
+		fmt.Printf("%s Error copying skill: %v\n", red("✗"), err)
+		return err
+	}
+	fmt.Printf("%s Skill copied\n", green("✓"))
+	fmt.Println()
+
+	// Step 8: Commit and push changes
+	fmt.Printf("%s Committing and pushing changes...\n", cyan("→"))
+	commitMsg := fmt.Sprintf("Add skill: %s", skillName)
+	if err := commitAndPush(tempDir, branchName, commitMsg); err != nil {
+		fmt.Printf("%s Error committing/pushing: %v\n", red("✗"), err)
+		return err
+	}
+	fmt.Printf("%s Changes pushed\n", green("✓"))
+	fmt.Println()
+
+	// Step 9: Create pull request
+	fmt.Printf("%s Creating pull request...\n", cyan("→"))
+	prURL, err := createPullRequest(tempDir, targetRepo, branchName, skillName)
+	if err != nil {
+		fmt.Printf("%s Error creating PR: %v\n", red("✗"), err)
+		return err
+	}
+
+	fmt.Printf("%s Pull request created successfully!\n\n", green("✓"))
+	fmt.Printf("  PR URL: %s\n", green(prURL))
+
+	return nil
+}
+
+// validateSkillStructure validates that the folder is a valid skill
+func validateSkillStructure(path string) (bool, []string, error) {
+	var warnings []string
+
+	// Check if path exists and is a directory
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil, fmt.Errorf("path does not exist: %s", path)
+		}
+		return false, nil, err
+	}
+
+	if !info.IsDir() {
+		return false, nil, fmt.Errorf("path is not a directory: %s", path)
+	}
+
+	// Check for required SKILL.md file
+	skillMDPath := filepath.Join(path, "SKILL.md")
+	if _, err := os.Stat(skillMDPath); os.IsNotExist(err) {
+		return false, nil, fmt.Errorf("SKILL.md is required but not found")
+	}
+
+	// Check for optional directories
+	optionalDirs := []string{"scripts", "references", "assets"}
+	hasOptionalDir := false
+
+	for _, dir := range optionalDirs {
+		dirPath := filepath.Join(path, dir)
+		if _, err := os.Stat(dirPath); err == nil {
+			hasOptionalDir = true
+			break
+		}
+	}
+
+	if !hasOptionalDir {
+		warnings = append(warnings, "No optional directories found (scripts/, references/, assets/)")
+	}
+
+	return true, warnings, nil
+}
+
+// checkGHInstalled checks if gh CLI is installed
+func checkGHInstalled() error {
+	cmd := exec.Command("gh", "--version")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("gh CLI is not installed or not in PATH")
+	}
+	return nil
+}
+
+// forkRepository forks a repository and returns the fork URL
+func forkRepository(repoURL string) (string, error) {
+	// Extract owner/repo from URL
+	owner, repo, err := parseGitHubURL(repoURL)
+	if err != nil {
+		return "", err
+	}
+
+	// Fork using gh CLI
+	cmd := exec.Command("gh", "repo", "fork", fmt.Sprintf("%s/%s", owner, repo), "--clone=false")
+	output, err := cmd.CombinedOutput()
+
+	if err != nil {
+		// Check if already forked
+		if strings.Contains(string(output), "already exists") {
+			// Get the current user
+			userCmd := exec.Command("gh", "api", "user", "--jq", ".login")
+			userOutput, userErr := userCmd.Output()
+			if userErr != nil {
+				return "", fmt.Errorf("error getting current user: %w", userErr)
+			}
+			currentUser := strings.TrimSpace(string(userOutput))
+			return fmt.Sprintf("https://github.com/%s/%s.git", currentUser, repo), nil
+		}
+		return "", fmt.Errorf("error forking repository: %s", string(output))
+	}
+
+	// Extract fork URL from output
+	lines := strings.Split(string(output), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "github.com") {
+			// Extract URL
+			parts := strings.Fields(line)
+			for _, part := range parts {
+				if strings.Contains(part, "github.com") {
+					return part, nil
+				}
+			}
+		}
+	}
+
+	// Fallback: construct fork URL
+	userCmd := exec.Command("gh", "api", "user", "--jq", ".login")
+	userOutput, err := userCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("error getting current user: %w", err)
+	}
+	currentUser := strings.TrimSpace(string(userOutput))
+
+	return fmt.Sprintf("https://github.com/%s/%s.git", currentUser, repo), nil
+}
+
+// parseGitHubURL extracts owner and repo from a GitHub URL
+func parseGitHubURL(url string) (string, string, error) {
+	// Remove .git suffix
+	url = strings.TrimSuffix(url, ".git")
+
+	// Handle different URL formats
+	var parts []string
+
+	if strings.HasPrefix(url, "https://github.com/") {
+		url = strings.TrimPrefix(url, "https://github.com/")
+		parts = strings.Split(url, "/")
+	} else if strings.HasPrefix(url, "git@github.com:") {
+		url = strings.TrimPrefix(url, "git@github.com:")
+		parts = strings.Split(url, "/")
+	} else {
+		return "", "", fmt.Errorf("unsupported URL format: %s", url)
+	}
+
+	if len(parts) < 2 {
+		return "", "", fmt.Errorf("invalid GitHub URL: %s", url)
+	}
+
+	return parts[0], parts[1], nil
+}
+
+// cloneRepository clones a repository to the specified path
+func cloneRepository(url, destPath string) error {
+	cmd := exec.Command("git", "clone", url, destPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git clone failed: %w", err)
+	}
+
+	return nil
+}
+
+// createBranch creates a new git branch
+func createBranch(repoPath, branchName string) error {
+	cmd := exec.Command("git", "-C", repoPath, "checkout", "-b", branchName)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git checkout failed: %w", err)
+	}
+	return nil
+}
+
+// commitAndPush commits changes and pushes to remote
+func commitAndPush(repoPath, branchName, message string) error {
+	// Add all files
+	addCmd := exec.Command("git", "-C", repoPath, "add", ".")
+	if err := addCmd.Run(); err != nil {
+		return fmt.Errorf("git add failed: %w", err)
+	}
+
+	// Commit
+	commitCmd := exec.Command("git", "-C", repoPath, "commit", "-m", message)
+	if err := commitCmd.Run(); err != nil {
+		return fmt.Errorf("git commit failed: %w", err)
+	}
+
+	// Push
+	pushCmd := exec.Command("git", "-C", repoPath, "push", "-u", "origin", branchName)
+	pushCmd.Stdout = os.Stdout
+	pushCmd.Stderr = os.Stderr
+
+	if err := pushCmd.Run(); err != nil {
+		return fmt.Errorf("git push failed: %w", err)
+	}
+
+	return nil
+}
+
+// createPullRequest creates a pull request and returns the PR URL
+func createPullRequest(repoPath, targetRepo, branchName, skillName string) (string, error) {
+	// Extract owner/repo from target URL
+	owner, repo, err := parseGitHubURL(targetRepo)
+	if err != nil {
+		return "", err
+	}
+
+	prTitle := fmt.Sprintf("Add skill: %s", skillName)
+	prBody := fmt.Sprintf("This PR adds the skill '%s' to the repository.\n\nSkill structure:\n- SKILL.md: Skill documentation and metadata\n- Additional files and directories as needed", skillName)
+
+	// Create PR using gh CLI
+	cmd := exec.Command("gh", "pr", "create",
+		"-R", fmt.Sprintf("%s/%s", owner, repo),
+		"--base", "main",
+		"--head", branchName,
+		"--title", prTitle,
+		"--body", prBody,
+	)
+	cmd.Dir = repoPath
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("error creating PR: %s", string(output))
+	}
+
+	// Extract PR URL from output
+	prURL := strings.TrimSpace(string(output))
+	lines := strings.Split(prURL, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "https://github.com/") {
+			return strings.TrimSpace(line), nil
+		}
+	}
+
+	return prURL, nil
+}


### PR DESCRIPTION
## Description

This PR implements a new `skill share` command that allows users to share skills by forking a repository and creating a pull request automatically.

## Changes

### New Files
- `internal/cli/share.go`: Complete implementation of the share command

### Modified Files
- `internal/cli/root.go`: Registered new share command and updated help text
- `README.md`: Added documentation for the new command

## Features

✨ **skill share --path <path> [--repo <url>]**

### Workflow
1. ✅ Validates skill structure (requires SKILL.md)
2. ✅ Warns about missing optional directories (scripts/, references/, assets/)
3. ✅ Forks target repository using gh CLI
4. ✅ Clones fork to temporary directory
5. ✅ Creates new branch (add-skill-<name>)
6. ✅ Copies skill folder
7. ✅ Commits and pushes changes
8. ✅ Creates pull request
9. ✅ Returns PR URL

## Usage Examples

```bash
# Share to active repository
skill share --path ./my-skill

# Share to specific repository
skill share --path ./my-skill --repo https://github.com/org/skills

# Share with SSH URL
skill share --path ~/skills/deploy-app --repo git@github.com:org/skills.git
```

## Testing

- ✅ Skill structure validation works correctly
- ✅ Warnings shown for missing optional directories
- ✅ Error handling for missing SKILL.md
- ✅ Integration with existing command structure
- ✅ Colored output matches existing commands
- ✅ Help text displays correctly

## Requirements

- gh CLI must be installed and authenticated
- User must have permissions to fork the target repository

## Screenshots

Command help output:
```
$ skill share --help
Share a skill by forking a repository and creating a PR.
...
```

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)