### PR TITLE
feat: update repository before installing a skill

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -10,6 +10,7 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/silvinalucero/skill_cli/internal/config"
 	"github.com/silvinalucero/skill_cli/internal/errors"
+	"github.com/silvinalucero/skill_cli/internal/git"
 	"github.com/silvinalucero/skill_cli/internal/skill"
 	"github.com/spf13/cobra"
 )
@@ -127,9 +128,19 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	}
 
 	// Verify repository exists
-	if _, err := config.GetRepo(cfg, repoName); err != nil {
+	repo, err := config.GetRepo(cfg, repoName)
+	if err != nil {
 		fmt.Printf("%s Repository '%s' not found\n", red("✗"), repoName)
 		return errors.ErrRepoNotFound
+	}
+
+	// Update repository before installing
+	fmt.Printf("%s Updating repository '%s'...\n", cyan("→"), repoName)
+	if err := git.Pull(repo.LocalPath); err != nil {
+		fmt.Printf("%s Warning: could not update repository: %v\n", yellow("⚠"), err)
+		fmt.Println("  Continuing with local version...")
+	} else {
+		fmt.Printf("%s Repository updated\n", green("✓"))
 	}
 
 	// Get all skills from the repository


### PR DESCRIPTION
## Summary

- Runs `git pull` on the local repository at the start of the `install` command
- Ensures skills are up to date before installation
- If the pull fails (e.g. no network), shows a warning and continues with the local version

## Test plan

- [ ] Run `skills install` and verify output shows "Updating repository..." before listing skills
- [ ] Disconnect from network and run `skills install` — should warn and continue normally
- [ ] Verify that newly added skills in the remote repo appear after running `skills install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)